### PR TITLE
Fix regex for global settings configuration

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,7 +2,7 @@
 - name: Configure global settings.
   lineinfile:
     dest: "{{ postgresql_config_path }}/postgresql.conf"
-    regexp: "^#?{{ item.option }}.+$"
+    regexp: "^#?{{ item.option }}\\s*=.+$"
     line: "{{ item.option }} = '{{ item.value }}'"
     state: "{{ item.state | default('present') }}"
     mode: 0644


### PR DESCRIPTION
Fix regex for global settings configuration. Use full option name, not only prefix. 

Example:
 timezone = UTC
-#timezone_abbreviations = 'Default' 
+timezone = 'UTC+3'